### PR TITLE
Add a flag to track the mounted of the timer component

### DIFF
--- a/src/components/Timer.js
+++ b/src/components/Timer.js
@@ -11,17 +11,25 @@ class Timer extends React.Component {
         this.state = {
             time: props.timer,
         };
+        this._isMounted = false;
     }
 
     componentDidMount() {
+        this._isMounted = true;
         setTimeout(() => {
             this.props.onEnd(this.props.index);
         }, 5000);
+
         setInterval(() => {
+            if (this._isMounted) {
             this.setState({
                 time: this.state.time - 1,
             })
-        }, 1000);
+        }}, 1000);
+    }
+
+    componentWillUnmount() {
+        this._isMounted = false;
     }
 
     render() {


### PR DESCRIPTION
The console contains a comprehensive description of the error - the error is due to an async function that is in `componentDidMount`. To fix the error, I added a flag that allows us not to change the state of a component if it is already unmounted.

Before fix:
<img width="1122" alt="Screenshot 2021-10-27 at 22 01 49" src="https://user-images.githubusercontent.com/48246024/139135911-c72f7d7a-1bd1-4dda-81ca-b85782da6e08.png">


After fix:
<img width="1126" alt="Screenshot 2021-10-27 at 22 03 08" src="https://user-images.githubusercontent.com/48246024/139135947-7ed68bb8-76da-4937-939c-bf71a182d3da.png">

